### PR TITLE
Add pushing to version.helsinki.fi to GH actions

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -26,3 +26,24 @@ jobs:
         run: |-
           docker build --tag "farmasiavr/farmasiavr-backend-prod:${{ github.event.release.tag_name }}" -f prod.Dockerfile . 
           docker push "farmasiavr/farmasiavr-backend-prod:${{ github.event.release.tag_name }}"
+  gitlab-tag:
+    name: Push release tag to version.helsinki.fi
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+        
+      - name: Set up git config
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+        
+      - name: Push to GitLab
+        env:
+          HELSINKIFI_TOKEN: ${{ secrets.HELSINKIFI_TOKEN }}
+        run: |
+          git remote add gitlab https://oauth2:${HELSINKIFI_TOKEN}@version.helsinki.fi/farmasiavr/farmasia-vr-certificate-backend.git
+          git push --tags -u gitlab main

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -27,3 +27,22 @@ jobs:
         run: |-
           docker build --tag "farmasiavr/farmasiavr-backend:latest" .
           docker push "farmasiavr/farmasiavr-backend:latest"
+  gitlab:
+    name: Push changes to version.helsinki.fi
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up git config
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+      - name: Push to version.helsinki.fi
+        env:
+          HELSINKIFI_TOKEN: ${{ secrets.HELSINKIFI_TOKEN }}
+        run: |
+          git remote add gitlab https://oauth2:${HELSINKIFI_TOKEN}@version.helsinki.fi/farmasiavr/farmasia-vr-certificate-backend.git
+          git push -u gitlab main


### PR DESCRIPTION
On every push to main pushes repo to remote GitLab instance hosted at [version.helsinki.fi](https://version.helsinki.fi/farmasiavr/farmasia-vr-certificate-backend). On every GH release pushes tags to the same remote. These are used to trigger webhook actions that activate deployments inside the university firewall.