### PR TITLE
Use secure cookie when not in development environment

### DIFF
--- a/utils/redis.js
+++ b/utils/redis.js
@@ -1,5 +1,5 @@
 import redis from 'redis'
-import { REDIS_URL, SESSION_SECRET } from './config.js'
+import { REDIS_URL, SESSION_SECRET, NODE_ENV } from './config.js'
 import session from 'express-session'
 import RedisStore from 'connect-redis'
 
@@ -37,7 +37,8 @@ const redisConf = {
   resave: false,
   saveUninitialized: false,
   cookie: {
-    maxAge: 24 * 60 * 60 * 1000
+    httpOnly: true,
+    secure: NODE_ENV === 'development' ? false : true
   }
 }
 


### PR DESCRIPTION
Fixes #5.

Sets cookie to `secure: true` when not in dev environment. Also removes maxAge attribute to make cookie truly a session cookie, and sets `httpOnly: true`.