### PR TITLE
Ignore gitlab server's state and just force push every time

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -47,7 +47,7 @@ jobs:
           HELSINKIFI_TOKEN: ${{ secrets.HELSINKIFI_TOKEN }}
         run: |
           git remote add gitlab https://oauth2:${HELSINKIFI_TOKEN}@version.helsinki.fi/farmasiavr/farmasia-vr-certificate-backend.git
-          git push gitlab --tags
+          git push gitlab --tags --force
       
       - name: Success
         run: |

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -45,4 +45,4 @@ jobs:
           HELSINKIFI_TOKEN: ${{ secrets.HELSINKIFI_TOKEN }}
         run: |
           git remote add gitlab https://oauth2:${HELSINKIFI_TOKEN}@version.helsinki.fi/farmasiavr/farmasia-vr-certificate-backend.git
-          git push -u gitlab main
+          git push -u gitlab main --force


### PR DESCRIPTION
GitLab is only for CI/CD so we don't need to be nice to it. It is not authoritative and no one is pulling from it.